### PR TITLE
fix: Refine FirstVisitCheckProvider to redirect only from the root path

### DIFF
--- a/src/shared/ui/FirstVisitCheckProvider.tsx
+++ b/src/shared/ui/FirstVisitCheckProvider.tsx
@@ -1,16 +1,17 @@
 import { useDormungStore } from '../store';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { useEffect } from 'react';
 
 export function FirstVisitCheckProvider({ children }: { children: React.ReactNode }) {
   const isFirstVisit = useDormungStore((state) => state.isFirstVisit);
   const navigate = useNavigate();
+  const location = useLocation();
 
   useEffect(() => {
-    if (isFirstVisit) {
+    if (isFirstVisit && location.pathname === '/') {
       navigate('/splash');
     }
-  }, [isFirstVisit, navigate]);
+  }, [isFirstVisit, navigate, location.pathname]);
 
   return <>{children}</>;
 }


### PR DESCRIPTION
- Updated the FirstVisitCheckProvider to check if the user is on the root path ('/') before navigating to the splash page on first visit.
- This change ensures that first-time users are redirected appropriately without affecting navigation from other routes.