### PR TITLE
fix: Center the step indicators in the OnboardingPage

### DIFF
--- a/src/pages/Onboarding.tsx
+++ b/src/pages/Onboarding.tsx
@@ -43,7 +43,7 @@ export function OnboardingPage() {
               onClick={() => setCurrentStep((prev) => prev - 1)}
             />
           )}
-          <ul className="flex gap-2">
+          <ul className="flex justify-center gap-2">
             <li className={cn('w-2 h-2 bg-white rounded-full z-[1]', currentStep === 1 && 'bg-[#FCD666]')} />
             <li className={cn('w-2 h-2 bg-white rounded-full z-[1]', currentStep === 2 && 'bg-[#FCD666]')} />
             <li className={cn('w-2 h-2 bg-white rounded-full z-[1]', currentStep === 3 && 'bg-[#FCD666]')} />


### PR DESCRIPTION
- Updated the class for the step indicators' container from 'gap-2' to 'justify-center gap-2' to ensure proper alignment and centering of the indicators.
- This change enhances the visual presentation of the onboarding steps, improving user experience.