### PR TITLE
fix: Update API endpoint in getHeritageById for accurate data retrieval

### DIFF
--- a/src/mocks/getHeritageById.ts
+++ b/src/mocks/getHeritageById.ts
@@ -1,7 +1,12 @@
 import { type Heritage } from '@/pages/home/api/getNearbyHeritages.mock';
 
 export const getHeritageById = async (id: string): Promise<Heritage | null> => {
-  const response = await fetch(`https://api.example.com/heritage/${id}`);
+  // https://dormung.goorm.training/api/tour-spots/location
+  const response = await fetch(`https://dormung.goorm.training/api/tour-spots/location/${id}`);
   const data = await response.json();
   return data ?? null;
+  // const response = await fetch(`https://api.example.com/heritage/${id}`);
+  // const data = await response.json();
+  // return data ?? null;
 };
+// /api/tour-spots/detai


### PR DESCRIPTION
- Changed the API endpoint in `getHeritageById.ts` to fetch data from the new URL: `https://dormung.goorm.training/api/tour-spots/location/${id}`.
- The previous commented-out code for the old endpoint has been retained for reference.
- This update aims to ensure accurate retrieval of heritage data based on the specified ID.