### PR TITLE
feat: 기존 하드 코딩된 API 주소를 apiClient 패턴으로 변경 및 간헐적으로 안되었던 audio 를 loading UI 없이 바로 재생/정지 되도록 변경

### DIFF
--- a/src/mocks/getHeritageById.ts
+++ b/src/mocks/getHeritageById.ts
@@ -1,12 +1,16 @@
+import { apiClient } from '@/shared/lib/axios';
 // import { type Heritage } from '@/pages/home/api/getNearbyHeritages.mock';
 
 // https://dormung.goorm.training/api/tour-spots/location
 // https://dormung.goorm.training/api/tour-spots/detail?contentId=CONT_000000000500150
 // https://dormung.goorm.training/api/tour-spots/detail?contentId=CONT_000000000500150&latitude=33.462147&longitude=126.936424
 export const getHeritageById = async (id: string, lat: number, lng: number): Promise<any | null> => {
-  const response = await fetch(
-    `https://dormung.goorm.training/api/tour-spots/detail?contentId=${id}&latitude=${lat}&longitude=${lng}`,
-  );
-  const data = await response.json();
-  return data ?? null;
+  const response = await apiClient.get(`/tour-spots/detail?contentId=${id}&latitude=${lat}&longitude=${lng}`);
+  return response.data;
+
+  // const response = await fetch(
+  //   `https://dormung.goorm.training/api/tour-spots/detail?contentId=${id}&latitude=${lat}&longitude=${lng}`,
+  // );
+  // const data = await response.json();
+  // return data ?? null;
 };

--- a/src/pages/home/api/getNearbyHeritages.ts
+++ b/src/pages/home/api/getNearbyHeritages.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import { apiClient } from '@/shared/lib/axios';
 
 export type Heritage = {
   externalId: string;
@@ -20,9 +20,13 @@ export const getNearbyHeritages = async (lat: number, lng: number, radius: numbe
   // longitude (required): 경도 (BigDecimal)
   // radius (optional): 반경(km), 기본값 10, 최대 10
 
-  const response = await axios.get<Heritage[]>('https://dormung.goorm.training/api/tour-spots/location', {
+  const response = await apiClient.get<Heritage[]>('/tour-spots/location', {
     params: { latitude: lat, longitude: lng, radius },
   });
+
+  // const response = await axios.get<Heritage[]>('https://dormung.goorm.training/api/tour-spots/location', {
+  //   params: { latitude: lat, longitude: lng, radius },
+  // });
 
   return response.data;
 };

--- a/src/pages/place-detail/lib/time.ts
+++ b/src/pages/place-detail/lib/time.ts
@@ -1,0 +1,5 @@
+export const formatTime = (time: number) => {
+  const minutes = Math.floor(time / 60);
+  const seconds = Math.floor(time % 60);
+  return `${minutes}:${seconds.toString().padStart(2, '0')}`;
+};

--- a/src/pages/place-detail/ui/PlaceDetailView.tsx
+++ b/src/pages/place-detail/ui/PlaceDetailView.tsx
@@ -37,8 +37,11 @@ export function PlaceDetailView({ heritage }: { heritage: Heritage }) {
     // save 데이터 저장
   };
 
-  const audioUrl = heritage?.audioUrl.replace('\r', '');
+  const audioUrlRaw = heritage?.audioUrl ?? '';
+  const audioUrl = audioUrlRaw.replace(/\r|\n/g, '').trim();
   const isHaveScript = !!heritage?.script;
+  const showPlayer = isHaveScript && Boolean(audioUrl);
+
   return (
     <Box className="bg-[#558CF5] h-screen">
       <Flex gap="$100" flexDirection="column" padding="$000" className="flex flex-col h-full">
@@ -68,7 +71,7 @@ export function PlaceDetailView({ heritage }: { heritage: Heritage }) {
           </div>
         </section>
 
-        {isHaveScript && (
+        {showPlayer && (
           <FixedBottom className="p-0">
             <AudioPlayer onCompleteAudio={onCompleteAudio} audioUrl={audioUrl} />
           </FixedBottom>

--- a/src/pages/search/api/index.ts
+++ b/src/pages/search/api/index.ts
@@ -1,8 +1,7 @@
+import { apiClient } from '@/shared/lib/axios';
 // "https://dormung.goorm.training/api/tour-spots/search?keyword=%EC%84%B1%EC%82%B0&latitude=33.462147&longitude=126.936424"
 
 export const search = async (query: string) => {
-  // const response = await fetch(`https://api.example.com/search?query=${query}`);
-  const response = await fetch(`https://dormung.goorm.training/api/tour-spots/search?keyword=${query}`);
-  const data = await response.json();
-  return data;
+  const response = await apiClient.get(`/tour-spots/search?keyword=${query}`);
+  return response.data;
 };


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

closes #34 


## 📋 작업 내용
- audio 를 loading UI 없이 바로 재생/정지 되도록 변경
- 기존 하드 코딩된 API 주소를 apiClient 패턴으로 변경


## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

- 제가 수민님 작업 영역까지 건들이긴 했는데 apiClient 만 적용되게 했습니다. 
-> 기존 api 요청 형태는 그대로 두고 apiClient 만 활용하는 형태로 변경했습니다. 

